### PR TITLE
Radius configuration for each screen

### DIFF
--- a/ovrvnc.toml
+++ b/ovrvnc.toml
@@ -8,6 +8,7 @@ host = "192.168.179.5"
 #password = ""
 latitude  = -15.0
 #longitude = 0.0
+radius = 1.5
 #lossy = true
 use_pointer = false
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ More complex example:
 	#password = ""
 	latitude  = -15.0
 	#longitude = 0.0
+	radius  = 1.5
 	#lossy = true
 	use_pointer = false
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -14,6 +14,7 @@ struct config_t {
 		std::string password;
 		float       latitude    = 0.0f;
 		float       longitude   = 0.0f;
+		float       radius      = 1.0f;
 		bool        lossy       = true;
 		bool        use_pointer = true;
 	};
@@ -50,6 +51,7 @@ inline config_t config_load( std::string const& fn ) {
 				screen->get_as<std::string>( "password" ).value_or( d.password ),
 				float( screen->get_as<double>( "latitude"  ).value_or( d.latitude ) ),
 				float( screen->get_as<double>( "longitude" ).value_or( d.longitude ) ),
+				float( screen->get_as<double>( "radius"  ).value_or( d.radius ) ),
 				screen->get_as<bool>( "lossy" ).value_or( d.lossy ),
 				screen->get_as<bool>( "use_pointer" ).value_or( d.use_pointer )
 			} );

--- a/src/ovrapp.cpp
+++ b/src/ovrapp.cpp
@@ -38,6 +38,7 @@ struct application_t: OVR::VrAppInterface {
 			for( auto const& screen: _config.screens ) {
 				auto vnc = std::make_unique<vnc_layer_t>();
 				vnc->resolution = _config.resolution;
+				vnc->radius = screen.radius;
 				vnc->transform =
 					OVR::Matrix4f::RotationY( float( M_PI / 180.0 ) * screen.longitude ) *
 					OVR::Matrix4f::RotationX( float( M_PI / 180.0 ) * screen.latitude  );

--- a/src/vnc_layer.hpp
+++ b/src/vnc_layer.hpp
@@ -83,7 +83,7 @@ struct vnc_layer_t {
 		// the shape of cylinder is hard-coded in SDK: 180 deg around, 60 deg vertical FOV.
 		float const sx = resolution / float( _screen_w );
 		float const fy = float( std::sqrt( 3.0 ) * M_PI / 2.0 ) * float( _screen_h ) / resolution;
-		OVR::Matrix4f const m_m = transform * OVR::Matrix4f::Scaling( radius, radius * fy, radius );
+		OVR::Matrix4f const m_m = transform * OVR::Matrix4f::Scaling( radius, fy, radius );
 
 		ovrLayerCylinder2 layer = vrapi_DefaultLayerCylinder2();
 		layer.Header.SrcBlend = VRAPI_FRAME_LAYER_BLEND_ONE;
@@ -95,14 +95,14 @@ struct vnc_layer_t {
 			layer.Textures[eye].SwapChainIndex = 0;
 
 			layer.Textures[eye].TexCoordsFromTanAngles = (OVR::Matrix4f( tracking.Eye[eye].ViewMatrix ) * m_m).Inverted();
-			layer.Textures[eye].TextureMatrix.M[0][0] = sx;
-			layer.Textures[eye].TextureMatrix.M[0][2] = -0.5f * sx + 0.5f;
+			layer.Textures[eye].TextureMatrix.M[0][0] = sx * radius;
+			layer.Textures[eye].TextureMatrix.M[0][2] = -0.5f * (sx * radius) + 0.5f;
 		}
 		return layer;
 	}
 
-	double        resolution  =  0.0;
-	double        radius      = 10.0;
+	double        resolution  = 0.0;
+	double        radius      = 1.0;
 	OVR::Matrix4f transform;
 	bool          use_pointer = true;
 


### PR DESCRIPTION
- Corrected transformation and texture matrices in vnc_layer.hpp
- Added radius configuration for each screen in config.hpp

半径の挙動を修正し，各スクリーンに半径を設定できるパラメータを追加しました．